### PR TITLE
WinRT support

### DIFF
--- a/include/dirent.h
+++ b/include/dirent.h
@@ -346,8 +346,16 @@ _wopendir(
         dirp->patt = NULL;
         dirp->cached = 0;
 
-        /* Compute the length of full path plus zero terminator */
-        n = GetFullPathNameW (dirname, 0, NULL, NULL);
+        /* Compute the length of full path plus zero terminator
+         * 
+         * Note that on WinRT there's no way to convert relative paths
+         * into absolute paths, so just assume its an absolute path.
+         */
+#       if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP)
+            n = wcslen(dirname);
+#       else
+            n = GetFullPathNameW (dirname, 0, NULL, NULL);
+#       endif
 
         /* Allocate room for absolute directory name and search pattern */
         dirp->patt = (wchar_t*) malloc (sizeof (wchar_t) * n + 16);
@@ -357,8 +365,15 @@ _wopendir(
              * Convert relative directory name to an absolute one.  This
              * allows rewinddir() to function correctly even when current
              * working directory is changed between opendir() and rewinddir().
+             * 
+             * Note that on WinRT there's no way to convert relative paths
+             * into absolute paths, so just assume its an absolute path.
              */
-            n = GetFullPathNameW (dirname, n, dirp->patt, NULL);
+#           if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP)
+                wcsncpy_s(dirp->patt, n+1, dirname, n);
+#           else
+                n = GetFullPathNameW (dirname, n, dirp->patt, NULL);
+#           endif
             if (n > 0) {
                 wchar_t *p;
 

--- a/include/dirent.h
+++ b/include/dirent.h
@@ -540,7 +540,7 @@ dirent_first(
     WIN32_FIND_DATAW *datap;
 
     /* Open directory and retrieve the first entry */
-    dirp->handle = FindFirstFileW (dirp->patt, &dirp->data);
+    dirp->handle = FindFirstFileExW (dirp->patt, FindExInfoStandard, &dirp->data, FindExSearchNameMatch, NULL, 0);
     if (dirp->handle != INVALID_HANDLE_VALUE) {
 
         /* a directory entry is now waiting in memory */

--- a/include/dirent.h
+++ b/include/dirent.h
@@ -24,8 +24,7 @@
 
 #include <stdio.h>
 #include <stdarg.h>
-#include <windef.h>
-#include <winbase.h>
+#include <windows.h>
 #include <wchar.h>
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
This commit resolves #2.

Sadly, WinRT doesn't seem to have any APIs for resolving relative paths (`GetFullPathNameW` isn't available and while `_wfullpath` compiles, it always returns `NULL`), so this commit only resolves relative paths when on regular Win32.

I've tested this fix under the following compilers and runtimes:
 * Compiled with Visual Studio 2015
   * Run on Win10 desktop
   * Run on Win10 phone
   * Run on Win8.1 phone
 * Compiled with Visual Studio 2013
    * Run on Win7 desktop
    * Run Win10 desktop