### PR TITLE
Update cmake to only use dirent header on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,15 +3,11 @@ project (dirent)
 
 enable_language (C)
 
-install (FILES include/dirent.h DESTINATION include)
-
-# Add include directory to path if current system omits dirent.h file.  This
-# step is imporant for compiling the test programs under Linux.
-include (CheckIncludeFiles)
-check_include_files (dirent.h HAVE_DIRENT_H)
-if (NOT HAVE_DIRENT_H)
+# Only use the dirent file on windows systems
+if (WIN32)
     include_directories (${CMAKE_SOURCE_DIR}/include)
-endif (NOT HAVE_DIRENT_H)
+    install (FILES include/dirent.h DESTINATION include)
+endif()
 
 # Build example programs
 add_executable (find examples/find.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@ enable_language (C)
 if (WIN32)
     include_directories (${CMAKE_SOURCE_DIR}/include)
     install (FILES include/dirent.h DESTINATION include)
+else()
+    cmake_policy(SET CMP0037 OLD) # Supress warnings about fake install
+    add_custom_target(install) # Fake install target
 endif()
 
 # Build example programs


### PR DESCRIPTION
So checking for the include, breaks the test on mingw, because mingw has the header but is not feature complete. Instead, I updated to only use the header on windows, otherwise use the system.

I also, updated it to only install the header on windows. So on linux it doesn't install anything since its not necessary. However, to make it successfully install with cget, I added a fake install target that does nothing.