### PR TITLE
Trim trailing whitespaces

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -40,7 +40,7 @@
 
 	* Version 1.13.1: patch from Edward Berner fixes set_errno() on
 	Windows NT 4.0.
-	
+
 	* Revised wcstombs() and mbstowcs() wrappers to make sure that they do
 	not write past their target string.
 

--- a/examples/find.c
+++ b/examples/find.c
@@ -35,7 +35,7 @@ static int find_directory (const char *dirname);
 
 int
 main(
-    int argc, char *argv[]) 
+    int argc, char *argv[])
 {
     int i;
     int ok;
@@ -115,7 +115,7 @@ find_directory(
 
             case DT_DIR:
                 /* Scan sub-directory recursively */
-                if (strcmp (ent->d_name, ".") != 0  
+                if (strcmp (ent->d_name, ".") != 0
                         &&  strcmp (ent->d_name, "..") != 0) {
                     find_directory (buffer);
                 }

--- a/examples/locate.c
+++ b/examples/locate.c
@@ -49,7 +49,7 @@ static FILE *db = NULL;
 
 int
 main(
-    int argc, char *argv[]) 
+    int argc, char *argv[])
 {
 #ifdef WIN32
     int i;
@@ -125,7 +125,7 @@ db_locate(
 /* Match pattern against file name */
 static int
 db_match(
-    const wchar_t *fn, const wchar_t *pattern) 
+    const wchar_t *fn, const wchar_t *pattern)
 {
     int found = 0;
 
@@ -182,7 +182,7 @@ db_match(
     return found;
 }
 
-/* 
+/*
  * Read line from locate.db.  This function is same as fgetws() except
  * that new-line at the end of line is not included.
  */

--- a/examples/ls.c
+++ b/examples/ls.c
@@ -35,7 +35,7 @@ static void list_directory (const char *dirname);
 
 int
 main(
-    int argc, char *argv[]) 
+    int argc, char *argv[])
 {
     int i;
 

--- a/examples/scandir.c
+++ b/examples/scandir.c
@@ -31,7 +31,7 @@ static void list_directory (const char *dirname);
 
 int
 main(
-    int argc, char *argv[]) 
+    int argc, char *argv[])
 {
     int i;
 

--- a/examples/updatedb.c
+++ b/examples/updatedb.c
@@ -51,7 +51,7 @@ static FILE *db = NULL;
 
 int
 main(
-    int argc, char *argv[]) 
+    int argc, char *argv[])
 {
 #ifdef WIN32
     int i;
@@ -158,7 +158,7 @@ update_directory(
 
             case DT_DIR:
                 /* Scan sub-directory recursively */
-                if (wcscmp (ent->d_name, L".") != 0  
+                if (wcscmp (ent->d_name, L".") != 0
                         &&  wcscmp (ent->d_name, L"..") != 0) {
                     update_directory (buffer);
                 }

--- a/include/dirent.h
+++ b/include/dirent.h
@@ -620,7 +620,7 @@ dirent_first(
 /*
  * Get next directory entry (internal).
  *
- * Returns 
+ * Returns
  */
 static WIN32_FIND_DATAW*
 dirent_next(
@@ -663,7 +663,7 @@ dirent_next(
  */
 static DIR*
 opendir(
-    const char *dirname) 
+    const char *dirname)
 {
     struct DIR *dirp;
     int error;

--- a/tests/t-compile.c
+++ b/tests/t-compile.c
@@ -17,7 +17,7 @@
 
 int
 main(
-    int argc, char *argv[]) 
+    int argc, char *argv[])
 {
     struct dirent *dirp = NULL;
 

--- a/tests/t-cplusplus.cpp
+++ b/tests/t-cplusplus.cpp
@@ -19,7 +19,7 @@ static int only_readme (const struct dirent *entry);
 
 int
 main(
-    int argc, char *argv[]) 
+    int argc, char *argv[])
 {
     (void) argc;
     (void) argv;


### PR DESCRIPTION
This patch trims trailing whitespaces across the code base for convenience of editing code. Certain editors and IDEs trim trailing whitespaces automatically on save action. To not have trailing whitespaces changes as a part of code commits this patch solves this.

Thank you.