### PR TITLE
Fix implicit cast warning on 64-bit UWP

### DIFF
--- a/include/dirent.h
+++ b/include/dirent.h
@@ -354,7 +354,13 @@ _wopendir(
     const wchar_t *dirname)
 {
     _WDIR *dirp;
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+    /* Desktop */
     DWORD n;
+#else
+    /* WinRT */
+    size_t n;
+#endif
     wchar_t *p;
 
     /* Must have directory name */


### PR DESCRIPTION
Hi!
In `simdjson`,  we use this awesome library to build some tools on Windows. And because we don't want to miss any warning, so `/WX` compiler option is always specified when building with MSVC.

Recently, I was trying to update `simdjson` included in `vcpkg` to the lastest version, and the CI of `vcpkg` reports a build failure on `x64-uwp`. The build log can be downloaded from here: https://dev.azure.com/vcpkg/public/_build/results?buildId=37460&view=artifacts&type=publishedArtifacts

On 64-bit UWP, size_t is 64-bit, DWORD is 32-bit. And an implicit cast is performed. When /WX compiler option is specified, error occurs:
> error C2220: the following warning is treated as an error [C:\agent\_work\1\s\buildtrees\simdjson\x64-uwp-dbg\tests\numberparsingcheck.vcxproj]
    21>C:\agent\_work\1\s\buildtrees\simdjson\src\1a0bae0ddd-6da2169b6a\windows\toni_ronnko_dirent.h(373,22): warning C4267: '=': conversion from 'size_t' to 'DWORD', possible loss of data

I have tested this patch in `vcpkg`'s CI, and it works: https://dev.azure.com/vcpkg/public/_build/results?buildId=37463&view=results

Related:
1. https://github.com/microsoft/vcpkg/pull/10709 
2. https://github.com/simdjson/simdjson/pull/896
