### PR TITLE
Add example program: dirls.c

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ if(DIRENT_BUILD_TESTS)
     add_executable (updatedb examples/updatedb.c)
     add_executable (scandir examples/scandir.c)
     add_executable (cat examples/cat.c)
+    add_executable (dirls examples/dirls.c)
 
     # Build test programs
     include (CTest)

--- a/examples/dirls.c
+++ b/examples/dirls.c
@@ -4,7 +4,7 @@
  * Compile this file with Visual Studio and run the produced command in
  * console with a directory name argument.  For example, command
  *
- *     dirls "c:\Files"
+ *     dirls "C:\Users\User1\Documents"
  *
  * might output something like
  *
@@ -153,7 +153,8 @@ static void list_size(const char* full_path)
 }
 
 /*
- * Combine directory and file name; return full path to file.
+ * Combine directory and file name.
+ * Write full path to memory.
  */
 static void get_full_path(
     const char* dirname, const char* filename, char* path_pointer)

--- a/examples/dirls.c
+++ b/examples/dirls.c
@@ -13,13 +13,13 @@
  *     budget.xlsx 19180
  *     directory_1/
  *     directory_2/
- *     shopping_list.txt 320
+ *     notes.txt 320
  *     to_do_list.txt 245
  *
  * The dirls command provided by this file is only an example: the command
  * does not have any fancy options.
  *
- * Copyright (C) 1998-2019 Toni Ronkko
+ * Copyright (C) 2006-2012 Toni Ronkko
  * This file is part of dirent.  Dirent may be freely distributed
  * under the MIT license.  For all details and documentation, see
  * https://github.com/tronkko/dirent
@@ -70,6 +70,8 @@ static void list_directory(const char* dirname)
     if (!dir) {
         /* Could not open directory; print error message */
         char msg_buff[ERR_MSG_LEN];
+
+        /* Function replaces strerror with strerror_s */
         print_error_msg(dirname, msg_buff);
 
         exit(EXIT_FAILURE);
@@ -114,6 +116,19 @@ static void list_directory(const char* dirname)
 }
 
 /*
+ * Print file size next to file name.
+ */
+static void list_size(const char* full_path)
+{
+    struct stat stbuf;
+
+    if (stat(full_path, &stbuf) == -1)
+        printf("%s %s\n", "Can't access", full_path);
+    else
+        printf("%d\n", stbuf.st_size);
+}
+
+/*
  * Enforce error message size limit and ensure valid error number.
  * Print error message.
  */
@@ -137,19 +152,6 @@ static void print_error_msg(const char* dirname, char* msg_buff)
             ERR_MSG_LEN);
         break;
     }
-}
-
-/*
- * Print file size next to file name.
- */
-static void list_size(const char* full_path)
-{
-    struct stat stbuf;
-
-    if (stat(full_path, &stbuf) == -1)
-        printf("%s %s\n", "Can't access", full_path);
-    else
-        printf("%d\n", stbuf.st_size);
 }
 
 /*

--- a/examples/dirls.c
+++ b/examples/dirls.c
@@ -1,0 +1,167 @@
+/*
+ * An example demonstrating basic file information listing.
+ *
+ * Compile this file with Visual Studio and run the produced command in
+ * console with a directory name argument.  For example, command
+ *
+ *     dirls "c:\Files"
+ *
+ * might output something like
+ *
+ *     ./
+ *     ../
+ *     budget.xlsx 19180
+ *     directory_1/
+ *     directory_2/
+ *     shopping_list.txt 320
+ *     to_do_list.txt 245
+ *
+ * The dirls command provided by this file is only an example: the command
+ * does not have any fancy options.
+ *
+ * Copyright (C) 2006-2012 Toni Ronkko
+ * This file is part of dirent.  Dirent may be freely distributed
+ * under the MIT license.  For all details and documentation, see
+ * https://github.com/tronkko/dirent
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <dirent.h>
+#include <errno.h>
+#include <locale.h>
+
+static void list_directory(const char* dirname);
+static void list_size(const char* full_path);
+static void get_full_path(const char* dirname, const char* filename,
+    char* path_pointer);
+
+
+int main(int argc, char* argv[])
+{
+    /* Select default locale */
+    setlocale(LC_ALL, "");
+
+    /* For each directory in command line. */
+    int i = 1;
+    while (i < argc) {
+        list_directory(argv[i]);
+        i++;
+        printf("\n");
+    }
+
+    /* List current working directory if no arguments on command line */
+    if (argc == 1)
+        list_directory(".");
+
+    return EXIT_SUCCESS;
+}
+
+/*
+ * List files and file sizes in directory.
+ */
+static void list_directory(const char* dirname)
+{
+    /* Open directory stream */
+    DIR* dir = opendir(dirname);
+    if (!dir) {
+        /* Could not open directory */
+        fprintf(stderr,
+            "Cannot open %s (%s)\n", dirname, strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    struct dirent* ent;
+    char path[MAX_PATH];
+    /* Print all files, file sizes, and directories within the directory */
+    while ((ent = readdir(dir)) != NULL) {
+        switch (ent->d_type) {
+        case DT_REG:
+            printf("%s ", ent->d_name);
+            /* Get full file path */
+            get_full_path(dirname, ent->d_name, path);
+            /* Print file size next to file name */
+            list_size(path);
+            break;
+
+        case DT_DIR:
+            printf("%s/\n", ent->d_name);
+            break;
+
+        case DT_LNK:
+            printf("%s@ ", ent->d_name);
+            /* Get full file path */
+            get_full_path(dirname, ent->d_name, path);
+            /* Print file size next to file name */
+            list_size(path);
+            break;
+
+        default:
+            printf("%s* ", ent->d_name);
+            /* Get full file path */
+            get_full_path(dirname, ent->d_name, path);
+            /* Print file size next to file name */
+            list_size(path);
+            break;
+        }
+    }
+
+    closedir(dir);
+}
+
+/*
+ * Print file size next to file name.
+ */
+static void list_size(const char* full_path)
+{
+    struct stat stbuf;
+
+    if (stat(full_path, &stbuf) == -1)
+        printf("%s %s\n", "Can't access", full_path);
+    else
+        printf("%d\n", stbuf.st_size);
+}
+
+/*
+ * Combine directory and file name; return full path to file.
+ */
+static void get_full_path(
+    const char* dirname, const char* filename, char* path_pointer)
+{
+    /* If '\' is included in command line argument at end of file path */
+    if (dirname[strlen(dirname) - 1] == '\\') {
+        /* Combine path and filename to create full path */
+        size_t total = strlen(dirname) + strlen(filename);
+        int j;
+        for (j = 0; j < strlen(dirname); j++) {
+            path_pointer[j] = dirname[j];
+        }
+
+        int i = 0;
+        for (i = 0; i < strlen(filename); i++) {
+            path_pointer[j] = filename[i];
+            j++;
+        }
+        path_pointer[j] = '\0';
+    }
+    /* Add '\' to end of command line argument if not included by user */
+    else {
+        /* Combine path and filename to create full path */
+        size_t total = strlen(dirname) + strlen(filename);
+        int j;
+        for (j = 0; j < strlen(dirname); j++) {
+            path_pointer[j] = dirname[j];
+        }
+
+        /* Add backslash after directory path, before file name. */
+        path_pointer[j] = '\\';
+
+        int i = 0;
+        j++;
+        for (i = 0; i < strlen(filename); i++) {
+            path_pointer[j] = filename[i];
+            j++;
+        }
+        path_pointer[j] = '\0';
+    }
+}

--- a/examples/dirls.c
+++ b/examples/dirls.c
@@ -19,7 +19,7 @@
  * The dirls command provided by this file is only an example: the command
  * does not have any fancy options.
  *
- * Copyright (C) 2006-2012 Toni Ronkko
+ * Copyright (C) 1998-2019 Toni Ronkko
  * This file is part of dirent.  Dirent may be freely distributed
  * under the MIT license.  For all details and documentation, see
  * https://github.com/tronkko/dirent

--- a/examples/dirls.c
+++ b/examples/dirls.c
@@ -4,7 +4,7 @@
  * Compile this file with Visual Studio and run the produced command in
  * console with a directory name argument.  For example, command
  *
- *     dirls "C:\Users\User1\Documents"
+ *     dirls "C:\Users\User 1\Documents"
  *
  * might output something like
  *


### PR DESCRIPTION
An example program demonstrating basic file information listing.

Example input:

dirls "C:\Users\User 1\Documents"

Might output something like:

./
 ../
 budget.xlsx 19180
 directory_1/
 directory_2/
notes.txt 320
 to_do_list.txt 245

Bug found upon further testing.

Input:

dirls c:

Produces the following:

./
../
<next file or directory from working directory INSTEAD of next file or directory from c:\\>
<next file or directory from working directory INSTEAD of next file or directory from c:\\>
<next file or directory from working directory INSTEAD of next file or directory from c:\\>
etc.