### PR TITLE
Improve UWP compatibility

### DIFF
--- a/include/dirent.h
+++ b/include/dirent.h
@@ -567,9 +567,15 @@ static WIN32_FIND_DATAW *dirent_first(_WDIR *dirp)
 		return NULL;
 
 	/* Open directory and retrieve the first entry */
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) && !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+	dirp->handle = FindFirstFileExFromAppW(
+		dirp->patt, FindExInfoStandard, &dirp->data,
+		FindExSearchNameMatch, NULL, 0);
+#else
 	dirp->handle = FindFirstFileExW(
 		dirp->patt, FindExInfoStandard, &dirp->data,
 		FindExSearchNameMatch, NULL, 0);
+#endif
 	if (dirp->handle == INVALID_HANDLE_VALUE)
 		goto error;
 

--- a/include/dirent.h
+++ b/include/dirent.h
@@ -388,7 +388,7 @@ static _WDIR *_wopendir(const wchar_t *dirname)
 	 * Note that on WinRT there's no way to convert relative paths
 	 * into absolute paths, so just assume it is an absolute path.
 	 */
-#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP | WINAPI_PARTITION_SYSTEM | WINAPI_PARTITION_GAMES)
 	/* Desktop */
 	DWORD n = GetFullPathNameW(dirname, 0, NULL, NULL);
 #else
@@ -409,7 +409,7 @@ static _WDIR *_wopendir(const wchar_t *dirname)
 	 * Note that on WinRT there's no way to convert relative paths
 	 * into absolute paths, so just assume it is an absolute path.
 	 */
-#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP | WINAPI_PARTITION_SYSTEM | WINAPI_PARTITION_GAMES)
 	/* Desktop */
 	n = GetFullPathNameW(dirname, n, dirp->patt, NULL);
 	if (n <= 0)


### PR DESCRIPTION
- For `GetFullPathNameW`, I copied the `#if WINAPI_FAMILY_PARTITION` directive which surrounds the function in the Windows 11 SDK (10.0.22000.0).
- For `FindFirstFileExFromAppW`, I copied the `#if WINAPI_FAMILY_PARTITION` directive which surrounds the function in the Windows 11 SDK (10.0.22000.0) but I removed the desktop part to prevent the additional linking to WindowsApp.lib when building win32 apps.